### PR TITLE
Fix typo of method name used in Collection doc

### DIFF
--- a/docs/content/en/expectations/collections.md
+++ b/docs/content/en/expectations/collections.md
@@ -20,5 +20,5 @@ expect(collect[1,2,3])->toBeCollection();
 Assert that the value is an instance of \Illuminate\Database\Eloquent\Collection.
 
 ```php
-expect(User::all())->toBeCollection();
+expect(User::all())->toBeEloquentCollection();
  ```


### PR DESCRIPTION
This PR will update the example used for the `toBeEloquentCollection` expectation to use the correct name.