### PR TITLE
Encode double quote so that badges are rendered correctly

### DIFF
--- a/docs/content/en/index.md
+++ b/docs/content/en/index.md
@@ -14,11 +14,11 @@ fullscreen: true
     <img style="display: inline-block; margin-top: 0.5em; margin-bottom: 0.5em" src="https://img.shields.io/packagist/v/defstudio/pest-plugin-laravel-expectations.svg?style=flat-square" alt="Latest Version on Packagist">
 </a>
 
-<a href="https://github.com/defstudio/pest-plugin-laravel-expectations/actions?query=workflow%3A"Run+Tests"+branch%3Amaster" target="_blank">
+<a href="https://github.com/defstudio/pest-plugin-laravel-expectations/actions?query=workflow%3A%22Run+Tests%22+branch%3Amaster" target="_blank">
     <img style="display: inline-block; margin-top: 0.5em; margin-bottom: 0.5em" src="https://img.shields.io/github/actions/workflow/status/defstudio/pest-plugin-laravel-expectations/tests.yml?branch=master&label=tests" alt="GitHub Tests Action Status">
 </a>
 
-<a href="https://github.com/defstudio/pest-plugin-laravel-expectations/actions?query=workflow%3A"Static+Analysis"+branch%3Amaster" target="_blank">
+<a href="https://github.com/defstudio/pest-plugin-laravel-expectations/actions?query=workflow%3A%22Static+Analysis%22+branch%3Amaster" target="_blank">
     <img style="display: inline-block; margin-top: 0.5em; margin-bottom: 0.5em" src="https://img.shields.io/github/actions/workflow/status/defstudio/pest-plugin-laravel-expectations/static.yml?branch=master&label=code%20style" alt="GitHub Code Style Action Status">
 </a>
 


### PR DESCRIPTION
This PR will convert `"` to `%22` in the URL used in the badge so that it can be rendered correctly.