### PR TITLE
Added Pest 5 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,9 +34,9 @@
         "illuminate/http": "^10.0|^11.0.3|^12.0|^13.0",
         "illuminate/support": "^10.0|^11.0.3|^12.0|^13.0",
         "illuminate/testing": "^10.0|^11.0.3|^12.0|^13.0",
-        "pestphp/pest": "^2.0|^3.0|^4.0",
-        "pestphp/pest-plugin": "^2.0|^3.0|^4.0",
-        "pestphp/pest-plugin-laravel": "^2.0|^3.0|^4.0"
+        "pestphp/pest": "^2.0|^3.0|^4.0|^5.0",
+        "pestphp/pest-plugin": "^2.0|^3.0|^4.0|^5.0",
+        "pestphp/pest-plugin-laravel": "^2.0|^3.0|^4.0|^5.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR adds support for [Pest 5](https://pestphp.com/docs/pest5-now-available). Test were already failing because of #136.